### PR TITLE
system agnostic db file path

### DIFF
--- a/ReqOverflow.Web/DataAccess/DataContext.cs
+++ b/ReqOverflow.Web/DataAccess/DataContext.cs
@@ -162,7 +162,7 @@ namespace ReqOverflow.Web.DataAccess
         {
             private static readonly object LockObj = new object();
 
-            private readonly string _databaseFilePath = Environment.ExpandEnvironmentVariables(@"%TMP%\ReqOverflowDb.json");
+            private readonly string _databaseFilePath = Path.Combine(Path.GetTempPath(), @"ReqOverflowDb.json");
 
             public void SaveToFile(string json)
             {


### PR DESCRIPTION
`%TMP%` does not resolve to correct temp dir on Linux. In fact, it leads to creation of file named `%TMP%\ReqOverflowDb.json`.

It seems better to use dotnet's system agnostic `Path.GetTempPath()`, which works correctly both on Windows and Linux.