### PR TITLE
Update default password due to password breach

### DIFF
--- a/ReqOverflow.Specs.API/Support/DomainDefaults.cs
+++ b/ReqOverflow.Specs.API/Support/DomainDefaults.cs
@@ -13,7 +13,7 @@ namespace ReqOverflow.Specs.Support
     public static class DomainDefaults
     {
         public const string UserName = "Marvin";
-        public const string UserPassword = "1234";
+        public const string UserPassword = "r)pF0*50oBs4";
 
         public const string AltUserName = "Ford";
         public const string AltUserPassword = "1423";

--- a/ReqOverflow.Specs.Controller/Support/DomainDefaults.cs
+++ b/ReqOverflow.Specs.Controller/Support/DomainDefaults.cs
@@ -9,7 +9,7 @@ namespace ReqOverflow.Specs.Support
     public static class DomainDefaults
     {
         public const string UserName = "Marvin";
-        public const string UserPassword = "1234";
+        public const string UserPassword = "r)pF0*50oBs4";
 
         public const string AltUserName = "Ford";
         public const string AltUserPassword = "1423";

--- a/ReqOverflow.Specs.WebUI/Support/DomainDefaults.cs
+++ b/ReqOverflow.Specs.WebUI/Support/DomainDefaults.cs
@@ -13,7 +13,7 @@ namespace ReqOverflow.Specs.Support
     public static class DomainDefaults
     {
         public const string UserName = "Marvin";
-        public const string UserPassword = "1234";
+        public const string UserPassword = "r)pF0*50oBs4";
 
         public const string AltUserName = "Ford";
         public const string AltUserPassword = "1423";

--- a/ReqOverflow.Tests/ModelTransformationServiceTests.cs
+++ b/ReqOverflow.Tests/ModelTransformationServiceTests.cs
@@ -58,7 +58,7 @@ namespace ReqOverflow.Tests
         [TestMethod]
         public void ToQuestionDetails_should_get_user_reference()
         {
-            var user = new User {Name = "XY", Password = "1234"};
+            var user = new User {Name = "XY", Password = "r)pF0*50oBs4"};
             _dataContext.Users.Add(user);
             var question = CreateBaseQuestion();
             question.AskedBy = user.Id;
@@ -106,7 +106,7 @@ namespace ReqOverflow.Tests
         [TestMethod]
         public void ToQuestionSummary_should_get_user_reference()
         {
-            var user = new User {Name = "XY", Password = "1234"};
+            var user = new User {Name = "XY", Password = "r)pF0*50oBs4"};
             _dataContext.Users.Add(user);
             var question = CreateBaseQuestion();
             question.AskedBy = user.Id;
@@ -149,7 +149,7 @@ namespace ReqOverflow.Tests
         [TestMethod]
         public void ToAnswerDetails_should_get_user_reference()
         {
-            var user = new User {Name = "XY", Password = "1234"};
+            var user = new User {Name = "XY", Password = "r)pF0*50oBs4"};
             _dataContext.Users.Add(user);
             var answer = new Answer { Content = "Content1", AnsweredBy = user.Id };
             var sut = new ModelTransformationService(_dataContext);
@@ -163,7 +163,7 @@ namespace ReqOverflow.Tests
         [TestMethod]
         public void ToUserReference_should_get_user_id_and_name()
         {
-            var user = new User {Name = "XY", Password = "1234"};
+            var user = new User {Name = "XY", Password = "r)pF0*50oBs4"};
             var sut = new ModelTransformationService(_dataContext);
 
             var result = sut.ToUserReference(user);

--- a/ReqOverflow.Web/Services/DefaultDataServices.cs
+++ b/ReqOverflow.Web/Services/DefaultDataServices.cs
@@ -11,7 +11,7 @@ namespace ReqOverflow.Web.Services
     public static class DefaultDataServices
     {
         public const string DefaultUserName = "Marvin";
-        public const string DefaultPassword = "1234";
+        public const string DefaultPassword = "r)pF0*50oBs4";
 
         public const string AltUserName = "Ford";
         public const string AltUserPassword = "1423";


### PR DESCRIPTION
### 🤔 What's changed?

Instances of the password `1234` have been replaced with a randomly generated one.

### ⚡️ What's your motivation? 

This prevents the UI tests from failing as Chrome displays a dialog that is invisible to webdriver and blocks UI interactions working correctly. Changing the password is a quick temporay fix for this issue (until the new password is found in a new breach). A longer term fix might include 
- adding a script to genearate new random passwrods and update usages
- more thoroughly investigate chrome security options to disable the warning or create a test profile where the password is already saved and the password breach has been dismissed

### 🏷️ What kind of change is this?

- :bug: Bug fix (non-breaking change which fixes a defect) for [this issue](https://github.com/dave99galloway/Sample-ReqOverflow/issues/2)

### 📋 Checklist:

- [x] I have added/updated tests to cover my changes.
